### PR TITLE
Refactor render tier system and enhance playground UX

### DIFF
--- a/packages/solid-glass/src/__tests__/effects.test.ts
+++ b/packages/solid-glass/src/__tests__/effects.test.ts
@@ -182,8 +182,8 @@ describe("renderGlass — refraction", () => {
     expect(result.className).toContain("sg-refraction--needs-measure");
   });
 
-  it("reports svg-filter renderTier", () => {
-    expect(templateRenderTiers.refraction).toBe("svg-filter");
+  it("reports svg-backdrop renderTier", () => {
+    expect(templateRenderTiers.refraction).toBe("svg-backdrop");
   });
 });
 

--- a/packages/solid-glass/src/__tests__/presets.test.ts
+++ b/packages/solid-glass/src/__tests__/presets.test.ts
@@ -121,6 +121,9 @@ describe("templateRenderTiers", () => {
   it("SVG filter templates are correct", () => {
     expect(templateRenderTiers.crystal).toBe("svg-filter");
     expect(templateRenderTiers.smoke).toBe("svg-filter");
-    expect(templateRenderTiers.refraction).toBe("svg-filter");
+  });
+
+  it("SVG backdrop templates are correct", () => {
+    expect(templateRenderTiers.refraction).toBe("svg-backdrop");
   });
 });

--- a/packages/solid-glass/src/effects/index.ts
+++ b/packages/solid-glass/src/effects/index.ts
@@ -33,7 +33,8 @@ export const effects: Record<GlassEffectName, GlassStyleGenerator<GlassBaseOptio
  * Rendering tier used by each effect.
  *
  * - `"css"` — Pure CSS (backdrop-filter, box-shadow, gradients)
- * - `"svg-filter"` — SVG filter primitives (feTurbulence, feDisplacementMap, etc.)
+ * - `"svg-filter"` — SVG filter via CSS `filter:` property (broadly supported)
+ * - `"svg-backdrop"` — SVG filter via CSS `backdrop-filter: url()` (Chromium 113+)
  * - `"webgl"` — GPU shaders (reserved for future use)
  */
 export const effectRenderTiers: Record<GlassEffectName, RenderTier> = {
@@ -44,7 +45,7 @@ export const effectRenderTiers: Record<GlassEffectName, RenderTier> = {
   prism: "css",
   holographic: "css",
   thin: "css",
-  refraction: "svg-filter",
+  refraction: "svg-backdrop",
 };
 
 /** Get a style generator by effect name */

--- a/packages/solid-glass/src/effects/refraction.ts
+++ b/packages/solid-glass/src/effects/refraction.ts
@@ -60,6 +60,6 @@ export const refraction: GlassStyleGenerator<RefractionGlassEffectOptions> = (op
       width: `${o.width}px`,
       height: `${o.height}px`,
     },
-    renderTier: "svg-filter",
+    renderTier: "svg-backdrop",
   };
 };

--- a/packages/solid-glass/src/render-glass.ts
+++ b/packages/solid-glass/src/render-glass.ts
@@ -23,9 +23,9 @@ export function renderGlass(
   // Check if browser supports the required render tier
   let effectiveBase = base;
   const requiredTier = templateRenderTiers[base];
-  if (requiredTier === "svg-filter" && typeof document !== "undefined") {
+  if (requiredTier === "svg-backdrop" && typeof document !== "undefined") {
     const supported = detectRenderTier();
-    if (supported === "css" && templateFallbacks[base]) {
+    if (supported !== "svg-backdrop" && supported !== "webgl" && templateFallbacks[base]) {
       effectiveBase = templateFallbacks[base]!;
       // Re-resolve with fallback template but keep user overrides
       const fallbackOpts = resolveTemplate(effectiveBase).options;
@@ -38,7 +38,7 @@ export function renderGlass(
 
       if (typeof console !== "undefined") {
         console.warn(
-          `[solid-glass] "${base}" requires SVG filters (Chromium 113+). ` +
+          `[solid-glass] "${base}" uses backdrop-filter: url() which requires Chromium 113+. ` +
           `Falling back to "${effectiveBase}". Pass fallback="${effectiveBase}" to silence this.`
         );
       }
@@ -210,7 +210,7 @@ function renderRefraction(o: GlassOptions): GlassRenderResult {
   if (!w || !h) {
     return {
       className: classNames("sg-refraction sg-refraction--needs-measure", o),
-      renderTier: "svg-filter",
+      renderTier: "svg-backdrop",
       cssVars: {
         ...commonVars(o),
       },
@@ -236,7 +236,7 @@ function renderRefraction(o: GlassOptions): GlassRenderResult {
 
   return {
     className: classNames("sg-refraction", o),
-    renderTier: "svg-filter",
+    renderTier: "svg-backdrop",
     cssVars: {
       "--sg-refraction-filter": result.filterRef,
       ...commonVars(o),

--- a/packages/solid-glass/src/templates.ts
+++ b/packages/solid-glass/src/templates.ts
@@ -124,13 +124,19 @@ export const templateRenderTiers: Record<TemplateName, RenderTier> = {
   prism: "css",
   holographic: "css",
   thin: "css",
-  refraction: "svg-filter",
+  refraction: "svg-backdrop",
 };
 
-/** CSS-only fallback mapping for SVG-filter templates */
+/**
+ * CSS-only fallback mapping.
+ *
+ * Only `svg-backdrop` templates need fallbacks — they use `backdrop-filter: url(#...)`
+ * which requires Chromium 113+.
+ *
+ * `svg-filter` templates (crystal, smoke) use standard CSS `filter: url(#...)` on top of
+ * `backdrop-filter: blur()`, which is broadly supported and does NOT need fallbacks.
+ */
 export const templateFallbacks: Partial<Record<TemplateName, TemplateName>> = {
-  crystal: "frosted",
-  smoke: "frosted",
   refraction: "frosted",
 };
 

--- a/packages/solid-glass/src/types.ts
+++ b/packages/solid-glass/src/types.ts
@@ -5,10 +5,13 @@ import type { SurfaceType } from "./engines/svg-refraction/surface-equations";
  * Rendering technology tier used by a template.
  *
  * - `"css"` — Pure CSS (backdrop-filter, box-shadow, gradients, animations).
- * - `"svg-filter"` — SVG filter primitives (feTurbulence, feDisplacementMap, etc.).
+ * - `"svg-filter"` — SVG filter via CSS `filter:` property (e.g. crystal, smoke).
+ *   Uses `backdrop-filter: blur()` + `filter: url(#svg)` — broadly supported.
+ * - `"svg-backdrop"` — SVG filter inside CSS `backdrop-filter: url(#...)` (e.g. refraction).
+ *   Chromium 113+ only — Firefox/Safari do not support SVG refs in backdrop-filter.
  * - `"webgl"` — GPU shaders (reserved for future use).
  */
-export type RenderTier = "css" | "svg-filter" | "webgl";
+export type RenderTier = "css" | "svg-filter" | "svg-backdrop" | "webgl";
 
 /**
  * Unified glass material options.

--- a/packages/solid-glass/src/utils.ts
+++ b/packages/solid-glass/src/utils.ts
@@ -33,7 +33,8 @@ import type { RenderTier } from "./types";
  * Detect the highest rendering tier supported by the current browser.
  *
  * - `"webgl"` — WebGL 2 or WebGPU available (future shader effects)
- * - `"svg-filter"` — SVG filters in `backdrop-filter` are supported (Chromium 113+)
+ * - `"svg-backdrop"` — SVG filters in `backdrop-filter: url()` are supported (Chromium 113+)
+ * - `"svg-filter"` — SVG filters via CSS `filter: url()` (all modern browsers)
  * - `"css"` — Basic CSS `backdrop-filter` support (Safari, Firefox, Chrome)
  *
  * Returns `"css"` in non-browser environments (SSR).
@@ -61,11 +62,14 @@ export function detectRenderTier(): RenderTier {
     const el = document.createElement("div");
     el.style.backdropFilter = "url(#test)";
     if (el.style.backdropFilter.includes("url")) {
-      return "svg-filter";
+      return "svg-backdrop";
     }
   } catch {
     // Not supported
   }
 
+  // svg-filter tier (CSS filter: url()) is supported in all modern browsers,
+  // but we return "css" here since we only use this function to gate
+  // svg-backdrop features. The svg-filter tier doesn't need runtime detection.
   return "css";
 }

--- a/packages/web/pages/docs/+Page.tsx
+++ b/packages/web/pages/docs/+Page.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { CodeBlock } from "../../src/components/CodeBlock";
+import { RenderTierInline } from "../../src/components/RenderTierTag";
 
 const sections = [
   {
@@ -293,10 +294,10 @@ element.style.backdropFilter = glass.filterRef;`} />
               </tr>
             </thead>
             <tbody className="text-slate-400">
-              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassCard</td><td>Frosted glass card with title/subtitle slots</td><td><span className="text-violet-400">CSS</span></td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassButton</td><td>Interactive glass button with hover states</td><td><span className="text-violet-400">CSS</span></td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">Loupe</td><td>Magnifying glass overlay</td><td><span className="text-emerald-400">SVG Filter</span></td></tr>
-              <tr><td className="py-3 text-white font-mono">RefractionPanel</td><td>Physics-based glass panel wrapper</td><td><span className="text-emerald-400">SVG Filter</span></td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassCard</td><td>Frosted glass card with title/subtitle slots</td><td><RenderTierInline tier="css" /></td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassButton</td><td>Interactive glass button with hover states</td><td><RenderTierInline tier="css" /></td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">Loupe</td><td>Magnifying glass overlay</td><td><RenderTierInline tier="svg-backdrop" /></td></tr>
+              <tr><td className="py-3 text-white font-mono">RefractionPanel</td><td>Physics-based glass panel wrapper</td><td><RenderTierInline tier="svg-backdrop" /></td></tr>
             </tbody>
           </table>
         </div>
@@ -307,28 +308,99 @@ element.style.backdropFilter = glass.filterRef;`} />
     ),
   },
   {
-    id: "browser-support",
-    title: "Browser Support",
+    id: "rendering-tiers",
+    title: "Rendering Tiers",
     content: (
       <>
+        <p className="text-slate-400 mb-4">
+          Solid-glass uses three rendering approaches. Each template is built on one of them, and browser support depends on which approach it uses — not on the template name.
+        </p>
+
+        {/* Tier 1: CSS */}
+        <div className="mb-6 bg-slate-800/40 border border-slate-700/50 rounded-xl p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="w-2 h-2 rounded-full bg-violet-400" />
+            <h4 className="text-white font-semibold text-sm">CSS</h4>
+            <span className="text-xs text-green-400 bg-green-500/10 border border-green-500/20 rounded-full px-2 py-0.5">All browsers</span>
+          </div>
+          <p className="text-slate-400 text-sm mb-2">
+            Pure CSS effects using <code className="text-blue-300">backdrop-filter: blur()</code>, box-shadow, gradients, and keyframe animations.
+            No SVG or JavaScript at render time.
+          </p>
+          <p className="text-slate-500 text-xs">
+            <strong className="text-slate-400">Templates:</strong> frosted, aurora, prism, holographic, thin
+          </p>
+        </div>
+
+        {/* Tier 2: SVG Filter */}
+        <div className="mb-6 bg-slate-800/40 border border-slate-700/50 rounded-xl p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="w-2 h-2 rounded-full bg-emerald-400" />
+            <h4 className="text-white font-semibold text-sm">CSS + SVG Filter</h4>
+            <span className="text-xs text-green-400 bg-green-500/10 border border-green-500/20 rounded-full px-2 py-0.5">All browsers</span>
+          </div>
+          <p className="text-slate-400 text-sm mb-2">
+            Standard <code className="text-blue-300">backdrop-filter: blur()</code> for the blur, plus an SVG displacement filter
+            applied via the CSS <code className="text-blue-300">filter: url(#id)</code> property.
+            Both are long-established, broadly supported CSS features that compose together — the SVG{" "}
+            <code className="text-blue-300">feTurbulence</code> distortion runs on the already-blurred backdrop.
+          </p>
+          <p className="text-slate-500 text-xs">
+            <strong className="text-slate-400">Templates:</strong> crystal, smoke
+          </p>
+        </div>
+
+        {/* Tier 3: SVG Backdrop */}
+        <div className="mb-6 bg-slate-800/40 border border-slate-700/50 rounded-xl p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="w-2 h-2 rounded-full bg-amber-400" />
+            <h4 className="text-white font-semibold text-sm">SVG Backdrop Filter</h4>
+            <span className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-full px-2 py-0.5">Chromium 113+</span>
+          </div>
+          <p className="text-slate-400 text-sm mb-2">
+            The entire SVG filter chain — Snell-Descartes displacement maps, specular highlights, saturation adjustments — is passed
+            directly as the <code className="text-blue-300">backdrop-filter</code> value:{" "}
+            <code className="text-blue-300">backdrop-filter: url(#svg-filter)</code>.
+            Only Chromium browsers support SVG filter references inside <code className="text-blue-300">backdrop-filter</code>;
+            Firefox and Safari will fall back to a simpler CSS effect automatically.
+          </p>
+          <p className="text-slate-500 text-xs">
+            <strong className="text-slate-400">Templates:</strong> refraction
+          </p>
+        </div>
+
+        {/* Key distinction callout */}
+        <div className="bg-blue-500/5 border border-blue-500/20 rounded-xl p-4 mb-6">
+          <p className="text-blue-300 text-sm font-medium mb-1">Why the distinction?</p>
+          <p className="text-slate-400 text-sm">
+            Crystal and smoke both generate <code className="text-slate-300">&lt;svg&gt;&lt;filter&gt;</code> elements, just like refraction.
+            The difference is <em>how</em> that SVG filter is applied in CSS.
+            Crystal/smoke use the standard CSS <code className="text-slate-300">filter</code> property to apply the SVG displacement on top of a regular <code className="text-slate-300">backdrop-filter: blur()</code> — two
+            broadly-supported features composed together.
+            Refraction puts the SVG filter <em>inside</em> <code className="text-slate-300">backdrop-filter</code> itself, which is a Chromium-only capability.
+          </p>
+        </div>
+
+        {/* Browser compat table */}
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-700">
                 <th className="text-left py-3 text-slate-300 font-semibold">Browser</th>
-                <th className="text-left py-3 text-slate-300 font-semibold">Support</th>
+                <th className="text-left py-3 text-slate-300 font-semibold"><span className="text-violet-400">CSS</span></th>
+                <th className="text-left py-3 text-slate-300 font-semibold"><span className="text-emerald-400">CSS + SVG Filter</span></th>
+                <th className="text-left py-3 text-slate-300 font-semibold"><span className="text-amber-400">SVG Backdrop</span></th>
               </tr>
             </thead>
             <tbody className="text-slate-400">
-              <tr className="border-b border-slate-800"><td className="py-3">Chrome / Edge</td><td>Full support</td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3">Safari</td><td>Blur works; SVG distortion limited</td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3">Firefox</td><td>Basic fallback (no distortion)</td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3">Chrome / Edge 113+</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3">Safari 15.4+</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td><td className="text-amber-400">Falls back to CSS</td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3">Firefox 103+</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td><td className="text-amber-400">Falls back to CSS</td></tr>
             </tbody>
           </table>
         </div>
-        <p className="text-slate-400 mt-4 text-sm">
-          All effects use progressive enhancement — if backdrop-filter isn't supported,
-          the tint/border still renders gracefully.
+        <p className="text-slate-500 text-sm mt-4">
+          All effects use progressive enhancement — unsupported tiers automatically fall back to a simpler rendering. The tint, border, and shadow always render.
         </p>
       </>
     ),

--- a/packages/web/pages/docs/+Page.tsx
+++ b/packages/web/pages/docs/+Page.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { CodeBlock } from "../../src/components/CodeBlock";
-import { RenderTierInline } from "../../src/components/RenderTierTag";
 
 const sections = [
   {
@@ -248,7 +247,7 @@ cleanup();`} />
       <>
         <p className="text-slate-400 mb-4">
           A separate physics-based engine that uses Snell-Descartes law and canvas-generated displacement maps
-          for realistic glass refraction. <strong className="text-white">Chromium-only.</strong>
+          for realistic glass refraction. <strong className="text-amber-400">Chrome & Edge only</strong> — other browsers get an automatic CSS fallback.
         </p>
         <CodeBlock code={`import { createLiquidGlass } from "solid-glass/engines/svg-refraction";
 
@@ -294,10 +293,10 @@ element.style.backdropFilter = glass.filterRef;`} />
               </tr>
             </thead>
             <tbody className="text-slate-400">
-              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassCard</td><td>Frosted glass card with title/subtitle slots</td><td><RenderTierInline tier="css" /></td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassButton</td><td>Interactive glass button with hover states</td><td><RenderTierInline tier="css" /></td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">Loupe</td><td>Magnifying glass overlay</td><td><RenderTierInline tier="svg-backdrop" /></td></tr>
-              <tr><td className="py-3 text-white font-mono">RefractionPanel</td><td>Physics-based glass panel wrapper</td><td><RenderTierInline tier="svg-backdrop" /></td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassCard</td><td>Frosted glass card with title/subtitle slots</td><td><span className="text-green-400">All browsers</span></td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">GlassButton</td><td>Interactive glass button with hover states</td><td><span className="text-green-400">All browsers</span></td></tr>
+              <tr className="border-b border-slate-800"><td className="py-3 text-white font-mono">Loupe</td><td>Magnifying glass overlay</td><td><span className="text-amber-400">Chrome & Edge</span></td></tr>
+              <tr><td className="py-3 text-white font-mono">RefractionPanel</td><td>Physics-based glass panel wrapper</td><td><span className="text-amber-400">Chrome & Edge</span></td></tr>
             </tbody>
           </table>
         </div>
@@ -308,100 +307,91 @@ element.style.backdropFilter = glass.filterRef;`} />
     ),
   },
   {
-    id: "rendering-tiers",
-    title: "Rendering Tiers",
+    id: "browser-support",
+    title: "Browser Support",
     content: (
       <>
-        <p className="text-slate-400 mb-4">
-          Solid-glass uses three rendering approaches. Each template is built on one of them, and browser support depends on which approach it uses — not on the template name.
+        <p className="text-slate-400 mb-6">
+          Most effects work in every modern browser. One — refraction — needs Chrome or Edge.
         </p>
 
-        {/* Tier 1: CSS */}
-        <div className="mb-6 bg-slate-800/40 border border-slate-700/50 rounded-xl p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="w-2 h-2 rounded-full bg-violet-400" />
-            <h4 className="text-white font-semibold text-sm">CSS</h4>
-            <span className="text-xs text-green-400 bg-green-500/10 border border-green-500/20 rounded-full px-2 py-0.5">All browsers</span>
-          </div>
-          <p className="text-slate-400 text-sm mb-2">
-            Pure CSS effects using <code className="text-blue-300">backdrop-filter: blur()</code>, box-shadow, gradients, and keyframe animations.
-            No SVG or JavaScript at render time.
-          </p>
-          <p className="text-slate-500 text-xs">
-            <strong className="text-slate-400">Templates:</strong> frosted, aurora, prism, holographic, thin
-          </p>
-        </div>
-
-        {/* Tier 2: SVG Filter */}
-        <div className="mb-6 bg-slate-800/40 border border-slate-700/50 rounded-xl p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="w-2 h-2 rounded-full bg-emerald-400" />
-            <h4 className="text-white font-semibold text-sm">CSS + SVG Filter</h4>
-            <span className="text-xs text-green-400 bg-green-500/10 border border-green-500/20 rounded-full px-2 py-0.5">All browsers</span>
-          </div>
-          <p className="text-slate-400 text-sm mb-2">
-            Standard <code className="text-blue-300">backdrop-filter: blur()</code> for the blur, plus an SVG displacement filter
-            applied via the CSS <code className="text-blue-300">filter: url(#id)</code> property.
-            Both are long-established, broadly supported CSS features that compose together — the SVG{" "}
-            <code className="text-blue-300">feTurbulence</code> distortion runs on the already-blurred backdrop.
-          </p>
-          <p className="text-slate-500 text-xs">
-            <strong className="text-slate-400">Templates:</strong> crystal, smoke
-          </p>
-        </div>
-
-        {/* Tier 3: SVG Backdrop */}
-        <div className="mb-6 bg-slate-800/40 border border-slate-700/50 rounded-xl p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <span className="w-2 h-2 rounded-full bg-amber-400" />
-            <h4 className="text-white font-semibold text-sm">SVG Backdrop Filter</h4>
-            <span className="text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-full px-2 py-0.5">Chromium 113+</span>
-          </div>
-          <p className="text-slate-400 text-sm mb-2">
-            The entire SVG filter chain — Snell-Descartes displacement maps, specular highlights, saturation adjustments — is passed
-            directly as the <code className="text-blue-300">backdrop-filter</code> value:{" "}
-            <code className="text-blue-300">backdrop-filter: url(#svg-filter)</code>.
-            Only Chromium browsers support SVG filter references inside <code className="text-blue-300">backdrop-filter</code>;
-            Firefox and Safari will fall back to a simpler CSS effect automatically.
-          </p>
-          <p className="text-slate-500 text-xs">
-            <strong className="text-slate-400">Templates:</strong> refraction
-          </p>
-        </div>
-
-        {/* Key distinction callout */}
-        <div className="bg-blue-500/5 border border-blue-500/20 rounded-xl p-4 mb-6">
-          <p className="text-blue-300 text-sm font-medium mb-1">Why the distinction?</p>
-          <p className="text-slate-400 text-sm">
-            Crystal and smoke both generate <code className="text-slate-300">&lt;svg&gt;&lt;filter&gt;</code> elements, just like refraction.
-            The difference is <em>how</em> that SVG filter is applied in CSS.
-            Crystal/smoke use the standard CSS <code className="text-slate-300">filter</code> property to apply the SVG displacement on top of a regular <code className="text-slate-300">backdrop-filter: blur()</code> — two
-            broadly-supported features composed together.
-            Refraction puts the SVG filter <em>inside</em> <code className="text-slate-300">backdrop-filter</code> itself, which is a Chromium-only capability.
-          </p>
-        </div>
-
-        {/* Browser compat table */}
-        <div className="overflow-x-auto">
+        {/* Compat table — lead with what users care about */}
+        <div className="overflow-x-auto mb-8">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-700">
-                <th className="text-left py-3 text-slate-300 font-semibold">Browser</th>
-                <th className="text-left py-3 text-slate-300 font-semibold"><span className="text-violet-400">CSS</span></th>
-                <th className="text-left py-3 text-slate-300 font-semibold"><span className="text-emerald-400">CSS + SVG Filter</span></th>
-                <th className="text-left py-3 text-slate-300 font-semibold"><span className="text-amber-400">SVG Backdrop</span></th>
+                <th className="text-left py-3 text-slate-300 font-semibold">Effect</th>
+                <th className="text-left py-3 text-slate-300 font-semibold">Chrome / Edge</th>
+                <th className="text-left py-3 text-slate-300 font-semibold">Safari</th>
+                <th className="text-left py-3 text-slate-300 font-semibold">Firefox</th>
               </tr>
             </thead>
             <tbody className="text-slate-400">
-              <tr className="border-b border-slate-800"><td className="py-3">Chrome / Edge 113+</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3">Safari 15.4+</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td><td className="text-amber-400">Falls back to CSS</td></tr>
-              <tr className="border-b border-slate-800"><td className="py-3">Firefox 103+</td><td className="text-green-400">Full</td><td className="text-green-400">Full</td><td className="text-amber-400">Falls back to CSS</td></tr>
+              <tr className="border-b border-slate-800">
+                <td className="py-3 text-white">frosted, aurora, prism, holographic, thin</td>
+                <td className="text-green-400">Full</td>
+                <td className="text-green-400">Full</td>
+                <td className="text-green-400">Full</td>
+              </tr>
+              <tr className="border-b border-slate-800">
+                <td className="py-3 text-white">crystal, smoke</td>
+                <td className="text-green-400">Full</td>
+                <td className="text-green-400">Full</td>
+                <td className="text-green-400">Full</td>
+              </tr>
+              <tr className="border-b border-slate-800">
+                <td className="py-3 text-white">refraction</td>
+                <td className="text-green-400">Full</td>
+                <td className="text-amber-400">CSS fallback</td>
+                <td className="text-amber-400">CSS fallback</td>
+              </tr>
             </tbody>
           </table>
         </div>
-        <p className="text-slate-500 text-sm mt-4">
-          All effects use progressive enhancement — unsupported tiers automatically fall back to a simpler rendering. The tint, border, and shadow always render.
+
+        <p className="text-slate-400 text-sm mb-6">
+          Fallbacks are automatic — you don't need to do anything. If a browser can't run the full effect,
+          it renders a simpler glass style instead. The tint, border, and shadow always show up.
         </p>
+
+        {/* Why refraction is different — for the curious */}
+        <details className="group bg-slate-800/40 border border-slate-700/50 rounded-xl">
+          <summary className="p-4 cursor-pointer select-none text-sm font-medium text-slate-300 hover:text-white">
+            Why is refraction Chrome-only?
+          </summary>
+          <div className="px-4 pb-4 space-y-3 text-sm text-slate-400">
+            <p>
+              All three groups above generate SVG <code className="text-slate-300">&lt;filter&gt;</code> elements
+              under the hood. The difference is how that filter reaches the screen:
+            </p>
+            <div className="space-y-2">
+              <div className="flex gap-3">
+                <span className="shrink-0 w-2 h-2 mt-1.5 rounded-full bg-violet-400" />
+                <p>
+                  <strong className="text-slate-300">frosted, aurora, etc.</strong> — pure CSS.
+                  <code className="text-blue-300 ml-1">backdrop-filter: blur()</code> does the work.
+                </p>
+              </div>
+              <div className="flex gap-3">
+                <span className="shrink-0 w-2 h-2 mt-1.5 rounded-full bg-emerald-400" />
+                <p>
+                  <strong className="text-slate-300">crystal, smoke</strong> — CSS blur <em>plus</em> an SVG distortion
+                  applied through the standard <code className="text-blue-300">filter</code> property.
+                  Two well-supported features layered together.
+                </p>
+              </div>
+              <div className="flex gap-3">
+                <span className="shrink-0 w-2 h-2 mt-1.5 rounded-full bg-amber-400" />
+                <p>
+                  <strong className="text-slate-300">refraction</strong> — the SVG filter goes <em>inside</em>{" "}
+                  <code className="text-blue-300">backdrop-filter: url(#...)</code> itself.
+                  Only Chromium supports passing an SVG reference to backdrop-filter.
+                  Firefox and Safari ignore it and get the CSS fallback.
+                </p>
+              </div>
+            </div>
+          </div>
+        </details>
       </>
     ),
   },

--- a/packages/web/src/components/RenderTierTag.tsx
+++ b/packages/web/src/components/RenderTierTag.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import { Sparkles, Gem, Box, Info, X } from "lucide-react";
+
+/**
+ * Render tier definitions — the single source of truth for how we label
+ * and explain each rendering approach across the whole site.
+ */
+const TIER_META: Record<
+  string,
+  {
+    label: string;
+    shortLabel: string;
+    icon: typeof Sparkles;
+    color: string;       // text + border Tailwind classes
+    bg: string;          // background Tailwind class
+    css: string;         // the actual CSS technique
+    compat: string;      // browser support one-liner
+    explanation: string; // 1-2 sentence plain-language explanation
+  }
+> = {
+  css: {
+    label: "CSS",
+    shortLabel: "CSS",
+    icon: Sparkles,
+    color: "text-violet-400 border-violet-500/20",
+    bg: "bg-violet-500/10",
+    css: "backdrop-filter: blur()",
+    compat: "All modern browsers",
+    explanation:
+      "Pure CSS effects using backdrop-filter, box-shadow, gradients, and animations. " +
+      "No SVG or JavaScript required at render time — just CSS custom properties.",
+  },
+  "svg-filter": {
+    label: "CSS + SVG Filter",
+    shortLabel: "SVG Filter",
+    icon: Gem,
+    color: "text-emerald-400 border-emerald-500/20",
+    bg: "bg-emerald-500/10",
+    css: "backdrop-filter: blur() + filter: url(#svg)",
+    compat: "All modern browsers",
+    explanation:
+      "Backdrop blur via standard CSS backdrop-filter, with an SVG displacement filter " +
+      "applied through the CSS filter property. Both are standard, broadly-supported features " +
+      "that compose together — the SVG feTurbulence distortion runs on the already-blurred backdrop.",
+  },
+  "svg-backdrop": {
+    label: "SVG Backdrop Filter",
+    shortLabel: "SVG Backdrop",
+    icon: Gem,
+    color: "text-amber-400 border-amber-500/20",
+    bg: "bg-amber-500/10",
+    css: "backdrop-filter: url(#svg)",
+    compat: "Chromium 113+ (Chrome, Edge, Opera)",
+    explanation:
+      "The entire SVG filter chain — including Snell-Descartes displacement maps and " +
+      "specular highlights — is passed directly as the backdrop-filter value. " +
+      "Only Chromium supports SVG filter references inside backdrop-filter; " +
+      "Firefox and Safari will fall back to a simpler CSS effect.",
+  },
+  webgl: {
+    label: "WebGL",
+    shortLabel: "WebGL",
+    icon: Box,
+    color: "text-amber-400 border-amber-500/20",
+    bg: "bg-amber-500/10",
+    css: "WebGL shaders",
+    compat: "GPU required",
+    explanation:
+      "GPU-accelerated rendering with custom shaders. Reserved for future effects.",
+  },
+};
+
+/**
+ * Compact badge — just the tier name and icon.
+ * Use in tight spaces (table cells, card headers, dropdown items).
+ */
+export function RenderTierBadge({ tier }: { tier: string }) {
+  const meta = TIER_META[tier] ?? TIER_META.css;
+  const Icon = meta.icon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[10px] font-medium ${meta.bg} ${meta.color} border rounded-full px-2 py-0.5`}
+    >
+      <Icon size={10} /> {meta.shortLabel}
+    </span>
+  );
+}
+
+/**
+ * Full tag — badge + compat indicator + expandable explanation.
+ * Use wherever there's room to educate (playground sidebar, component headers).
+ */
+export function RenderTierTag({ tier }: { tier: string }) {
+  const [open, setOpen] = useState(false);
+  const meta = TIER_META[tier] ?? TIER_META.css;
+  const Icon = meta.icon;
+  const isRestricted = tier === "svg-backdrop" || tier === "webgl";
+
+  return (
+    <div className="inline-flex flex-col items-start">
+      <button
+        onClick={() => setOpen(!open)}
+        className={`inline-flex items-center gap-1.5 text-[11px] font-medium ${meta.bg} ${meta.color} border rounded-full pl-2 pr-2.5 py-0.5 transition-colors hover:brightness-125`}
+      >
+        <Icon size={11} />
+        <span>{meta.label}</span>
+        {isRestricted && (
+          <span className="text-[9px] opacity-70 ml-0.5">— {meta.compat}</span>
+        )}
+        <Info size={10} className="opacity-50 ml-0.5" />
+      </button>
+
+      {open && (
+        <div className="mt-2 w-80 bg-slate-800 border border-slate-700 rounded-xl p-3.5 shadow-xl text-xs leading-relaxed">
+          <div className="flex items-start justify-between gap-2 mb-2">
+            <h4 className={`font-semibold ${meta.color.split(" ")[0]}`}>{meta.label}</h4>
+            <button onClick={() => setOpen(false)} className="text-slate-500 hover:text-white">
+              <X size={12} />
+            </button>
+          </div>
+
+          {/* CSS technique */}
+          <div className="mb-2">
+            <span className="text-slate-500 text-[10px] uppercase tracking-wider">CSS technique</span>
+            <div className="mt-0.5">
+              <code className="text-[11px] text-blue-300 bg-blue-500/10 rounded px-1.5 py-0.5">
+                {meta.css}
+              </code>
+            </div>
+          </div>
+
+          {/* Explanation */}
+          <p className="text-slate-400 mb-2">{meta.explanation}</p>
+
+          {/* Compat */}
+          <div className={`inline-flex items-center gap-1.5 text-[10px] rounded-full px-2 py-0.5 ${
+            isRestricted
+              ? "bg-amber-500/10 text-amber-400 border border-amber-500/20"
+              : "bg-green-500/10 text-green-400 border border-green-500/20"
+          }`}>
+            <span className={`w-1.5 h-1.5 rounded-full ${isRestricted ? "bg-amber-400" : "bg-green-400"}`} />
+            {meta.compat}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Inline compat note — the amber banner shown above the preview
+ * for Chromium-only effects.
+ */
+export function ChromiumNotice({ tier }: { tier: string }) {
+  if (tier !== "svg-backdrop") return null;
+  const meta = TIER_META[tier];
+  return (
+    <div className="text-center mb-4">
+      <span className="inline-flex items-center gap-2 text-xs text-amber-400/80 bg-amber-400/5 border border-amber-400/20 rounded-full px-3 py-1">
+        {meta.compat} — <code className="font-mono text-[11px]">{meta.css}</code> is not supported in Firefox or Safari
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Short tier label for table cells and tight inline use.
+ */
+export function RenderTierInline({ tier }: { tier: string }) {
+  const meta = TIER_META[tier] ?? TIER_META.css;
+  return (
+    <span className={meta.color.split(" ")[0]}>{meta.label}</span>
+  );
+}
+
+/** Exported for docs/pages that need the raw data */
+export { TIER_META };

--- a/packages/web/src/components/RenderTierTag.tsx
+++ b/packages/web/src/components/RenderTierTag.tsx
@@ -1,81 +1,91 @@
 import { useState } from "react";
-import { Sparkles, Gem, Box, Info, X } from "lucide-react";
+import { Sparkles, Gem, Box, Info, X, Globe, Monitor } from "lucide-react";
 
 /**
- * Render tier definitions — the single source of truth for how we label
- * and explain each rendering approach across the whole site.
+ * Effect engine definitions — single source of truth for how we label
+ * and explain each rendering approach to users across the site.
+ *
+ * Internal tier keys map to user-facing language:
+ *   "css"          → "Works everywhere"
+ *   "svg-filter"   → "Works everywhere" (just with SVG under the hood)
+ *   "svg-backdrop" → "Chrome & Edge only"
+ *   "webgl"        → "GPU required"
  */
-const TIER_META: Record<
+const ENGINE_META: Record<
   string,
   {
-    label: string;
-    shortLabel: string;
+    label: string;         // user-facing name
+    shortLabel: string;    // for tight spaces
     icon: typeof Sparkles;
-    color: string;       // text + border Tailwind classes
-    bg: string;          // background Tailwind class
-    css: string;         // the actual CSS technique
-    compat: string;      // browser support one-liner
-    explanation: string; // 1-2 sentence plain-language explanation
+    color: string;         // text + border Tailwind classes
+    bg: string;            // background Tailwind class
+    compat: string;        // browser support — user language
+    howItWorks: string;    // plain-language explanation
+    underTheHood: string;  // the CSS technique, for the curious
+    templates: string;     // which templates use this
   }
 > = {
   css: {
-    label: "CSS",
+    label: "Works everywhere",
     shortLabel: "CSS",
-    icon: Sparkles,
+    icon: Globe,
     color: "text-violet-400 border-violet-500/20",
     bg: "bg-violet-500/10",
-    css: "backdrop-filter: blur()",
     compat: "All modern browsers",
-    explanation:
-      "Pure CSS effects using backdrop-filter, box-shadow, gradients, and animations. " +
-      "No SVG or JavaScript required at render time — just CSS custom properties.",
+    howItWorks:
+      "These effects use standard CSS — blur, gradients, shadows, and animations. " +
+      "Nothing exotic, nothing to fall back from.",
+    underTheHood: "backdrop-filter: blur() + CSS gradients & box-shadow",
+    templates: "frosted, aurora, prism, holographic, thin",
   },
   "svg-filter": {
-    label: "CSS + SVG Filter",
-    shortLabel: "SVG Filter",
-    icon: Gem,
+    label: "Works everywhere",
+    shortLabel: "SVG",
+    icon: Globe,
     color: "text-emerald-400 border-emerald-500/20",
     bg: "bg-emerald-500/10",
-    css: "backdrop-filter: blur() + filter: url(#svg)",
     compat: "All modern browsers",
-    explanation:
-      "Backdrop blur via standard CSS backdrop-filter, with an SVG displacement filter " +
-      "applied through the CSS filter property. Both are standard, broadly-supported features " +
-      "that compose together — the SVG feTurbulence distortion runs on the already-blurred backdrop.",
+    howItWorks:
+      "These effects add an SVG distortion on top of the standard CSS blur. " +
+      "The blur and the SVG filter are two separate, well-supported features " +
+      "that layer together — no browser restrictions.",
+    underTheHood: "backdrop-filter: blur() + filter: url(#svg)",
+    templates: "crystal, smoke",
   },
   "svg-backdrop": {
-    label: "SVG Backdrop Filter",
-    shortLabel: "SVG Backdrop",
-    icon: Gem,
+    label: "Chrome & Edge only",
+    shortLabel: "Chrome only",
+    icon: Monitor,
     color: "text-amber-400 border-amber-500/20",
     bg: "bg-amber-500/10",
-    css: "backdrop-filter: url(#svg)",
-    compat: "Chromium 113+ (Chrome, Edge, Opera)",
-    explanation:
-      "The entire SVG filter chain — including Snell-Descartes displacement maps and " +
-      "specular highlights — is passed directly as the backdrop-filter value. " +
-      "Only Chromium supports SVG filter references inside backdrop-filter; " +
-      "Firefox and Safari will fall back to a simpler CSS effect.",
+    compat: "Chrome & Edge 113+",
+    howItWorks:
+      "The refraction engine bakes a physics simulation into an SVG filter and feeds it " +
+      "directly into backdrop-filter — a technique only Chromium browsers support today. " +
+      "In Firefox and Safari, it automatically falls back to a simpler glass effect.",
+    underTheHood: "backdrop-filter: url(#svg-displacement-map)",
+    templates: "refraction",
   },
   webgl: {
-    label: "WebGL",
+    label: "GPU required",
     shortLabel: "WebGL",
     icon: Box,
     color: "text-amber-400 border-amber-500/20",
     bg: "bg-amber-500/10",
-    css: "WebGL shaders",
-    compat: "GPU required",
-    explanation:
+    compat: "WebGL-capable browsers",
+    howItWorks:
       "GPU-accelerated rendering with custom shaders. Reserved for future effects.",
+    underTheHood: "WebGL shaders",
+    templates: "",
   },
 };
 
 /**
- * Compact badge — just the tier name and icon.
+ * Compact badge — compat-focused label.
  * Use in tight spaces (table cells, card headers, dropdown items).
  */
 export function RenderTierBadge({ tier }: { tier: string }) {
-  const meta = TIER_META[tier] ?? TIER_META.css;
+  const meta = ENGINE_META[tier] ?? ENGINE_META.css;
   const Icon = meta.icon;
   return (
     <span
@@ -87,12 +97,12 @@ export function RenderTierBadge({ tier }: { tier: string }) {
 }
 
 /**
- * Full tag — badge + compat indicator + expandable explanation.
+ * Full tag — badge + expandable explanation.
  * Use wherever there's room to educate (playground sidebar, component headers).
  */
 export function RenderTierTag({ tier }: { tier: string }) {
   const [open, setOpen] = useState(false);
-  const meta = TIER_META[tier] ?? TIER_META.css;
+  const meta = ENGINE_META[tier] ?? ENGINE_META.css;
   const Icon = meta.icon;
   const isRestricted = tier === "svg-backdrop" || tier === "webgl";
 
@@ -104,43 +114,30 @@ export function RenderTierTag({ tier }: { tier: string }) {
       >
         <Icon size={11} />
         <span>{meta.label}</span>
-        {isRestricted && (
-          <span className="text-[9px] opacity-70 ml-0.5">— {meta.compat}</span>
-        )}
         <Info size={10} className="opacity-50 ml-0.5" />
       </button>
 
       {open && (
         <div className="mt-2 w-80 bg-slate-800 border border-slate-700 rounded-xl p-3.5 shadow-xl text-xs leading-relaxed">
           <div className="flex items-start justify-between gap-2 mb-2">
-            <h4 className={`font-semibold ${meta.color.split(" ")[0]}`}>{meta.label}</h4>
+            <h4 className={`font-semibold ${meta.color.split(" ")[0]}`}>{meta.compat}</h4>
             <button onClick={() => setOpen(false)} className="text-slate-500 hover:text-white">
               <X size={12} />
             </button>
           </div>
 
-          {/* CSS technique */}
-          <div className="mb-2">
-            <span className="text-slate-500 text-[10px] uppercase tracking-wider">CSS technique</span>
-            <div className="mt-0.5">
-              <code className="text-[11px] text-blue-300 bg-blue-500/10 rounded px-1.5 py-0.5">
-                {meta.css}
-              </code>
-            </div>
-          </div>
-
           {/* Explanation */}
-          <p className="text-slate-400 mb-2">{meta.explanation}</p>
+          <p className="text-slate-400 mb-2.5">{meta.howItWorks}</p>
 
-          {/* Compat */}
-          <div className={`inline-flex items-center gap-1.5 text-[10px] rounded-full px-2 py-0.5 ${
-            isRestricted
-              ? "bg-amber-500/10 text-amber-400 border border-amber-500/20"
-              : "bg-green-500/10 text-green-400 border border-green-500/20"
-          }`}>
-            <span className={`w-1.5 h-1.5 rounded-full ${isRestricted ? "bg-amber-400" : "bg-green-400"}`} />
-            {meta.compat}
-          </div>
+          {/* Under the hood */}
+          <details className="group">
+            <summary className="text-slate-500 text-[10px] uppercase tracking-wider cursor-pointer hover:text-slate-300 select-none">
+              Under the hood
+            </summary>
+            <code className="block mt-1 text-[11px] text-blue-300 bg-blue-500/10 rounded px-1.5 py-1">
+              {meta.underTheHood}
+            </code>
+          </details>
         </div>
       )}
     </div>
@@ -149,29 +146,29 @@ export function RenderTierTag({ tier }: { tier: string }) {
 
 /**
  * Inline compat note — the amber banner shown above the preview
- * for Chromium-only effects.
+ * for Chrome-only effects.
  */
 export function ChromiumNotice({ tier }: { tier: string }) {
   if (tier !== "svg-backdrop") return null;
-  const meta = TIER_META[tier];
   return (
     <div className="text-center mb-4">
       <span className="inline-flex items-center gap-2 text-xs text-amber-400/80 bg-amber-400/5 border border-amber-400/20 rounded-full px-3 py-1">
-        {meta.compat} — <code className="font-mono text-[11px]">{meta.css}</code> is not supported in Firefox or Safari
+        <Monitor size={12} />
+        Chrome & Edge only — other browsers get an automatic CSS fallback
       </span>
     </div>
   );
 }
 
 /**
- * Short tier label for table cells and tight inline use.
+ * Short compat label for table cells and tight inline use.
  */
 export function RenderTierInline({ tier }: { tier: string }) {
-  const meta = TIER_META[tier] ?? TIER_META.css;
+  const meta = ENGINE_META[tier] ?? ENGINE_META.css;
   return (
-    <span className={meta.color.split(" ")[0]}>{meta.label}</span>
+    <span className={meta.color.split(" ")[0]}>{meta.compat}</span>
   );
 }
 
 /** Exported for docs/pages that need the raw data */
-export { TIER_META };
+export { ENGINE_META };

--- a/packages/web/src/pages/Components.tsx
+++ b/packages/web/src/pages/Components.tsx
@@ -1,31 +1,12 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { Glass } from "solid-glass";
 import { createLiquidGlass, type SurfaceType } from "solid-glass/engines/svg-refraction";
-import { Sparkles, Gem, Box, Search, Bell, X, Info, CheckCircle, AlertTriangle, User, Lock, Mail } from "lucide-react";
+import { Search, Bell, X, Info, CheckCircle, AlertTriangle, User, Lock, Mail } from "lucide-react";
 import { CodeBlock } from "../components/CodeBlock";
+import { RenderTierBadge } from "../components/RenderTierTag";
 
-/* ─── Render Tier Badge ─── */
-function TierBadge({ tier }: { tier: string }) {
-  if (tier === "svg-filter") {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 rounded-full px-2 py-0.5">
-        <Gem size={10} /> SVG Filter
-      </span>
-    );
-  }
-  if (tier === "webgl") {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded-full px-2 py-0.5">
-        <Box size={10} /> WebGL
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-violet-500/10 text-violet-400 border border-violet-500/20 rounded-full px-2 py-0.5">
-      <Sparkles size={10} /> CSS
-    </span>
-  );
-}
+/* TierBadge alias for shared component */
+const TierBadge = RenderTierBadge;
 
 const BG_IMAGE = "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&q=80";
 
@@ -171,11 +152,10 @@ function LoupeDemo() {
       <div>
         <div className="flex items-center gap-3 mb-2">
           <h3 className="text-xl font-bold text-white">Loupe</h3>
-          <TierBadge tier="svg-filter" />
+          <TierBadge tier="svg-backdrop" />
         </div>
         <p className="text-slate-400 text-sm">
           A magnifying glass component using the SVG refraction engine. Move your mouse over the image.
-          <span className="text-yellow-400/80 ml-1">(Chromium only)</span>
         </p>
       </div>
 
@@ -256,11 +236,10 @@ function RefractionPanelDemo() {
       <div>
         <div className="flex items-center gap-3 mb-2">
           <h3 className="text-xl font-bold text-white">RefractionPanel</h3>
-          <TierBadge tier="svg-filter" />
+          <TierBadge tier="svg-backdrop" />
         </div>
         <p className="text-slate-400 text-sm">
           A panel using the SVG refraction engine with Snell-Descartes law.
-          <span className="text-yellow-400/80 ml-1">(Chromium only)</span>
         </p>
       </div>
 
@@ -705,8 +684,8 @@ const COMPONENTS = [
   { id: "glass-tooltip", label: "GlassTooltip", tier: "css" as const, Component: GlassTooltipDemo },
   { id: "glass-toast", label: "GlassToast", tier: "css" as const, Component: GlassToastDemo },
   { id: "glass-form", label: "GlassForm", tier: "css" as const, Component: GlassFormDemo },
-  { id: "loupe", label: "Loupe", tier: "svg-filter" as const, Component: LoupeDemo },
-  { id: "liquid-glass-panel", label: "RefractionPanel", tier: "svg-filter" as const, Component: RefractionPanelDemo },
+  { id: "loupe", label: "Loupe", tier: "svg-backdrop" as const, Component: LoupeDemo },
+  { id: "liquid-glass-panel", label: "RefractionPanel", tier: "svg-backdrop" as const, Component: RefractionPanelDemo },
 ];
 
 export function Components() {
@@ -742,8 +721,8 @@ export function Components() {
                   }`}
                 >
                   <span className="font-mono">{c.label}</span>
-                  <span className={`ml-2 text-[9px] ${c.tier === "svg-filter" ? "text-emerald-500" : "text-violet-400"}`}>
-                    {c.tier === "svg-filter" ? "SVG Filter" : "CSS"}
+                  <span className={`ml-2 text-[9px] ${c.tier === "svg-backdrop" ? "text-amber-400" : c.tier === "svg-filter" ? "text-emerald-400" : "text-violet-400"}`}>
+                    {c.tier === "svg-backdrop" ? "SVG Backdrop" : c.tier === "svg-filter" ? "SVG Filter" : "CSS"}
                   </span>
                 </button>
               </li>

--- a/packages/web/src/pages/Components.tsx
+++ b/packages/web/src/pages/Components.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { Glass } from "solid-glass";
 import { createLiquidGlass, type SurfaceType } from "solid-glass/engines/svg-refraction";
-import { Search, Bell, X, Info, CheckCircle, AlertTriangle, User, Lock, Mail } from "lucide-react";
+import { Search, Bell, X, Info, CheckCircle, AlertTriangle, User, Lock, Mail, Gem } from "lucide-react";
 import { CodeBlock } from "../components/CodeBlock";
 import { RenderTierBadge } from "../components/RenderTierTag";
 

--- a/packages/web/src/pages/Components.tsx
+++ b/packages/web/src/pages/Components.tsx
@@ -721,8 +721,8 @@ export function Components() {
                   }`}
                 >
                   <span className="font-mono">{c.label}</span>
-                  <span className={`ml-2 text-[9px] ${c.tier === "svg-backdrop" ? "text-amber-400" : c.tier === "svg-filter" ? "text-emerald-400" : "text-violet-400"}`}>
-                    {c.tier === "svg-backdrop" ? "SVG Backdrop" : c.tier === "svg-filter" ? "SVG Filter" : "CSS"}
+                  <span className={`ml-2 text-[9px] ${c.tier === "svg-backdrop" ? "text-amber-400" : "text-violet-400"}`}>
+                    {c.tier === "svg-backdrop" ? "Chrome only" : "All browsers"}
                   </span>
                 </button>
               </li>

--- a/packages/web/src/pages/Gallery.tsx
+++ b/packages/web/src/pages/Gallery.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useMemo, useEffect } from "react";
 import { createLiquidGlass, type SurfaceType } from "solid-glass/engines/svg-refraction";
 import { templatePresets } from "solid-glass";
 import { EffectGrid } from "../components/EffectGrid";
+import { RenderTierBadge } from "../components/RenderTierTag";
 
 /** Refraction engine presets derived from template presets */
 const refractionPresets = {
@@ -70,8 +71,7 @@ function LoupeDemoCard() {
     <div className="space-y-3">
       <div className="flex items-center gap-2">
         <h3 className="text-sm font-semibold text-white">Loupe</h3>
-        <span className="text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 rounded-full px-2 py-0.5">SVG Filter</span>
-        <span className="text-[10px] text-yellow-400/70">Chromium</span>
+        <RenderTierBadge tier="svg-backdrop" />
       </div>
       <div
         ref={containerRef}
@@ -133,8 +133,7 @@ function RefractionDemoCard() {
     <div className="space-y-3">
       <div className="flex items-center gap-2">
         <h3 className="text-sm font-semibold text-white">Refraction Panel</h3>
-        <span className="text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 rounded-full px-2 py-0.5">SVG Filter</span>
-        <span className="text-[10px] text-yellow-400/70">Chromium</span>
+        <RenderTierBadge tier="svg-backdrop" />
       </div>
       <div className="flex gap-1.5 mb-2">
         {(["convexCircle", "convexSquircle", "concave", "lip"] as SurfaceType[]).map((s) => (

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import { Glass, type TemplateName, templatePresets, type TemplatePresetName, templatePresetNames, templateRenderTiers } from "solid-glass";
 import { createLiquidGlass, type SurfaceType, SURFACE_EQUATIONS } from "solid-glass/engines/svg-refraction";
-import { RotateCcw, Image, ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
+import { RotateCcw, Image, ChevronLeft, ChevronRight, ChevronDown, Link2 } from "lucide-react";
 import { CodeBlock } from "../components/CodeBlock";
 import { RenderTierBadge, RenderTierTag, ChromiumNotice } from "../components/RenderTierTag";
 
@@ -167,6 +167,109 @@ const SURFACE_TYPES: { key: SurfaceType; label: string }[] = [
 
 type FilterTab = "all" | "css" | "svg-filter" | "svg-backdrop" | "webgl";
 
+/* ─── Preview Size Presets ─── */
+type PreviewSize = { key: string; label: string; w: number; h: number };
+const PREVIEW_SIZES: PreviewSize[] = [
+  { key: "card", label: "Card", w: 280, h: 200 },
+  { key: "banner", label: "Banner", w: 480, h: 160 },
+  { key: "square", label: "Square", w: 240, h: 240 },
+  { key: "full", label: "Full", w: 0, h: 0 }, // 0 = fill container
+];
+
+/* ─── URL Hash State ─── */
+function encodeHashState(templateIndex: number, values: Record<string, number>, tintColor: string, surface?: SurfaceType): string {
+  const parts: string[] = [`t=${templateIndex}`];
+  const numEntries = Object.entries(values);
+  if (numEntries.length > 0) parts.push(`v=${numEntries.map(([k, v]) => `${k}:${v}`).join(",")}`);
+  if (tintColor !== "#ffffff") parts.push(`c=${tintColor.replace("#", "")}`);
+  if (surface) parts.push(`s=${surface}`);
+  return parts.join("&");
+}
+
+function decodeHashState(hash: string): { templateIndex: number; values: Record<string, number>; tintColor: string; surface?: SurfaceType } | null {
+  if (!hash || hash.length < 2) return null;
+  const params = new URLSearchParams(hash.replace(/^#/, ""));
+  const tStr = params.get("t");
+  if (tStr === null) return null;
+  const templateIndex = parseInt(tStr, 10);
+  if (isNaN(templateIndex) || templateIndex < 0 || templateIndex >= TEMPLATES.length) return null;
+
+  const values: Record<string, number> = {};
+  const vStr = params.get("v");
+  if (vStr) {
+    for (const pair of vStr.split(",")) {
+      const [k, v] = pair.split(":");
+      if (k && v) values[k] = parseFloat(v);
+    }
+  }
+
+  const cStr = params.get("c");
+  const tintColor = cStr ? `#${cStr}` : "#ffffff";
+  const surface = params.get("s") as SurfaceType | undefined;
+
+  return { templateIndex, values, tintColor, surface: surface || undefined };
+}
+
+/* ─── Editable Number Input ─── */
+function EditableValue({
+  value,
+  step,
+  min,
+  max,
+  onChange,
+  isModified,
+}: {
+  value: number;
+  step: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+  isModified: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const decimals = step < 1 ? Math.max(String(step).split(".")[1]?.length ?? 0, 2) : 0;
+  const display = decimals > 0 ? value.toFixed(decimals) : String(value);
+
+  const commit = () => {
+    const n = parseFloat(editText);
+    if (!isNaN(n)) onChange(Math.min(max, Math.max(min, n)));
+    setEditing(false);
+  };
+
+  useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={editText}
+        onChange={(e) => setEditText(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => { if (e.key === "Enter") commit(); if (e.key === "Escape") setEditing(false); }}
+        className="w-16 bg-slate-700 text-slate-200 text-[11px] font-mono tabular-nums rounded px-1.5 py-0.5 text-right outline-none ring-1 ring-blue-500"
+      />
+    );
+  }
+
+  return (
+    <button
+      onClick={() => { setEditText(display); setEditing(true); }}
+      className={`font-mono text-[11px] tabular-nums px-1.5 py-0.5 rounded transition-colors cursor-text ${
+        isModified ? "text-blue-400 bg-blue-500/10" : "text-slate-600 hover:text-slate-400 hover:bg-slate-800"
+      }`}
+      title="Click to type a value"
+    >
+      {display}
+    </button>
+  );
+}
+
 /* ═══════════════════════════════════════════════ */
 /*  Browse Mode — template gallery                  */
 /* ═══════════════════════════════════════════════ */
@@ -249,6 +352,75 @@ function BrowseView({ onSelect }: { onSelect: (index: number) => void }) {
 }
 
 /* ═══════════════════════════════════════════════ */
+/*  Grouped Dropdown for Template Switching        */
+/* ═══════════════════════════════════════════════ */
+function GroupedTemplateDropdown({
+  templateIndex,
+  onSelect,
+  open,
+  onToggle,
+}: {
+  templateIndex: number;
+  onSelect: (index: number) => void;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const template = TEMPLATES[templateIndex];
+  const tier = templateRenderTiers[template.template];
+
+  // Group templates by effect type
+  const groups = useMemo(() => {
+    const map = new Map<string, { template: Template; index: number }[]>();
+    TEMPLATES.forEach((t, i) => {
+      const key = t.template;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push({ template: t, index: i });
+    });
+    return map;
+  }, []);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={onToggle}
+        className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-slate-800 border border-slate-700 text-sm text-slate-200 hover:border-slate-500 transition-colors"
+      >
+        {template.name}
+        <RenderTierBadge tier={tier} />
+        <span className="text-[10px] text-slate-600 tabular-nums">{templateIndex + 1}/{TEMPLATES.length}</span>
+        <ChevronDown size={14} className={`text-slate-500 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 w-72 bg-slate-800 border border-slate-700 rounded-xl shadow-xl z-50 py-1 max-h-80 overflow-y-auto">
+          {[...groups.entries()].map(([effectType, items], gi) => (
+            <div key={effectType}>
+              {gi > 0 && <div className="mx-3 my-1 border-t border-slate-700/50" />}
+              <div className="px-3 pt-2 pb-1">
+                <span className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider">{effectType}</span>
+              </div>
+              {items.map(({ template: t, index: i }) => (
+                <button
+                  key={i}
+                  onClick={() => onSelect(i)}
+                  className={`w-full text-left px-3 py-1.5 text-sm transition-colors flex items-center justify-between ${
+                    i === templateIndex
+                      ? "bg-white/10 text-white"
+                      : "text-slate-300 hover:bg-slate-700"
+                  }`}
+                >
+                  <span className="font-medium">{t.name}</span>
+                  <RenderTierBadge tier={templateRenderTiers[t.template]} />
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════ */
 /*  Refraction Preview (tweak mode)                  */
 /* ═══════════════════════════════════════════════ */
 function RefractionPreview({
@@ -260,6 +432,8 @@ function RefractionPreview({
   gradientIndex,
   previewRef,
   onMouseMove,
+  panelWidth,
+  panelHeight,
 }: {
   surface: SurfaceType;
   values: Record<string, number>;
@@ -269,10 +443,10 @@ function RefractionPreview({
   gradientIndex: number;
   previewRef: React.RefObject<HTMLDivElement | null>;
   onMouseMove: (e: React.MouseEvent) => void;
+  panelWidth: number;
+  panelHeight: number;
 }) {
   const svgRef = useRef<Element | null>(null);
-  const panelWidth = 280;
-  const panelHeight = 200;
 
   const glass = useMemo(() => {
     return createLiquidGlass({
@@ -288,7 +462,7 @@ function RefractionPreview({
       saturation: getValue("refractionSaturation", 1.2),
       dpr: 1,
     });
-  }, [surface, values]);
+  }, [surface, values, panelWidth, panelHeight]);
 
   useEffect(() => {
     if (svgRef.current) svgRef.current.remove();
@@ -369,19 +543,27 @@ function TweakView({
   const [framework, setFramework] = useState<Framework>("react");
   const [mouseOffset, setMouseOffset] = useState({ x: 0, y: 0 });
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [previewSize, setPreviewSize] = useState<string>("card");
+  const [linkCopied, setLinkCopied] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
 
   const tmplName = template.template;
   const isRefraction = tmplName === "refraction";
   const tier = templateRenderTiers[tmplName];
 
-  // All templates for the same template type (for the dropdown)
-  const sameEffectTemplates = TEMPLATES
-    .map((t, i) => ({ ...t, index: i }))
-    .filter((t) => t.template === tmplName);
+  const sizePreset = PREVIEW_SIZES.find((s) => s.key === previewSize) ?? PREVIEW_SIZES[0];
+  const isFull = sizePreset.key === "full";
+  const panelWidth = isFull ? 440 : sizePreset.w;
+  const panelHeight = isFull ? 300 : sizePreset.h;
+
+  // Get template default value for a slider
+  const getTemplateDefault = (key: string): number | undefined => {
+    const val = template.overrides[key];
+    return typeof val === "number" ? val : undefined;
+  };
 
   // When switching templates, reload values
-  const switchTemplate = (idx: number) => {
+  const switchTemplate = useCallback((idx: number) => {
     const t = TEMPLATES[idx];
     const nv: Record<string, number> = {};
     for (const [k, v] of Object.entries(t.overrides)) {
@@ -393,7 +575,7 @@ function TweakView({
     if (t.surface) setSurface(t.surface);
     setDropdownOpen(false);
     onSwitch(idx);
-  };
+  }, [onSwitch]);
 
   // Keyboard navigation: left/right arrow keys
   useEffect(() => {
@@ -409,7 +591,13 @@ function TweakView({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [templateIndex]);
+  }, [templateIndex, switchTemplate]);
+
+  // Sync state to URL hash
+  useEffect(() => {
+    const hash = encodeHashState(templateIndex, values, tintColor, isRefraction ? surface : undefined);
+    window.history.replaceState(null, "", `#${hash}`);
+  }, [templateIndex, values, tintColor, surface, isRefraction]);
 
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     const rect = previewRef.current?.getBoundingClientRect();
@@ -421,6 +609,25 @@ function TweakView({
 
   const activeSliders = SLIDERS.filter((s) => s.templates.includes(tmplName));
   const getValue = (key: string, def: number) => values[key] ?? def;
+
+  // Only include values that differ from slider defaults (for cleaner code output)
+  const changedOptions = useMemo(() => {
+    const o: Record<string, unknown> = {};
+    activeSliders.forEach((s) => {
+      const current = getValue(s.key, s.defaultValue);
+      const templateVal = getTemplateDefault(s.key);
+      // Always include values that are set in the template overrides or differ from slider defaults
+      if (templateVal !== undefined || current !== s.defaultValue) {
+        o[s.key] = current;
+      }
+    });
+    if (["frosted", "crystal"].includes(tmplName)) o.tintColor = tintColor;
+    if (isRefraction && o.refractionSaturation !== undefined) {
+      o.saturation = o.refractionSaturation;
+      delete o.refractionSaturation;
+    }
+    return o;
+  }, [tmplName, values, tintColor, activeSliders, isRefraction]);
 
   const options = useMemo(() => {
     const o: Record<string, unknown> = {};
@@ -436,7 +643,7 @@ function TweakView({
   const codeSnippet = useMemo(() => {
     if (isRefraction) {
       return generateRefractionSnippet({
-        width: 280, height: 200,
+        width: panelWidth, height: panelHeight,
         radius: getValue("radius", 20),
         bezelWidth: getValue("bezelWidth", 50),
         glassThickness: getValue("glassThickness", 200),
@@ -446,8 +653,8 @@ function TweakView({
         specularOpacity: getValue("specularOpacity", 0.6),
       });
     }
-    return getSnippet(framework, tmplName, options);
-  }, [framework, tmplName, options, isRefraction, surface, values]);
+    return getSnippet(framework, tmplName, changedOptions);
+  }, [framework, tmplName, changedOptions, isRefraction, surface, values, panelWidth, panelHeight]);
 
   const resetToTemplate = () => {
     const nv: Record<string, number> = {};
@@ -460,9 +667,25 @@ function TweakView({
     if (template.surface) setSurface(template.surface);
   };
 
+  const copyLink = () => {
+    const url = window.location.href;
+    navigator.clipboard.writeText(url).then(() => {
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    });
+  };
+
+  // Count how many sliders are modified from template defaults
+  const modifiedCount = activeSliders.filter((s) => {
+    const templateVal = getTemplateDefault(s.key);
+    const current = getValue(s.key, s.defaultValue);
+    const base = templateVal ?? s.defaultValue;
+    return current !== base;
+  }).length;
+
   return (
     <div>
-      {/* Header: back + prev/next + template switcher */}
+      {/* Header: back + prev/next + template switcher + share */}
       <div className="flex items-center gap-3 mb-6">
         <button
           onClick={onBack}
@@ -488,38 +711,21 @@ function TweakView({
             <ChevronRight size={16} />
           </button>
         </div>
-        <div className="relative">
-          <button
-            onClick={() => setDropdownOpen(!dropdownOpen)}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-slate-800 border border-slate-700 text-sm text-slate-200 hover:border-slate-500 transition-colors"
-          >
-            {template.name}
-            <RenderTierBadge tier={tier} />
-            <span className="text-[10px] text-slate-600 tabular-nums">{templateIndex + 1}/{TEMPLATES.length}</span>
-            <ChevronDown size={14} className={`text-slate-500 transition-transform ${dropdownOpen ? "rotate-180" : ""}`} />
-          </button>
-          {dropdownOpen && (
-            <div className="absolute top-full left-0 mt-1 w-64 bg-slate-800 border border-slate-700 rounded-xl shadow-xl z-50 py-1 max-h-72 overflow-y-auto">
-              {TEMPLATES.map((t, i) => (
-                <button
-                  key={i}
-                  onClick={() => switchTemplate(i)}
-                  className={`w-full text-left px-3 py-2 text-sm transition-colors flex items-center justify-between ${
-                    i === templateIndex
-                      ? "bg-white/10 text-white"
-                      : "text-slate-300 hover:bg-slate-700"
-                  }`}
-                >
-                  <div>
-                    <span className="font-medium">{t.name}</span>
-                    <span className="text-[10px] text-slate-500 ml-2 capitalize">{t.template}</span>
-                  </div>
-                  <RenderTierBadge tier={templateRenderTiers[t.template]} />
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+        <GroupedTemplateDropdown
+          templateIndex={templateIndex}
+          onSelect={switchTemplate}
+          open={dropdownOpen}
+          onToggle={() => setDropdownOpen(!dropdownOpen)}
+        />
+        {/* Share link button */}
+        <button
+          onClick={copyLink}
+          className="ml-auto flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-slate-400 hover:text-white bg-slate-800 border border-slate-700 hover:border-slate-500 transition-colors"
+          title="Copy shareable link"
+        >
+          <Link2 size={13} />
+          {linkCopied ? "Copied!" : "Share"}
+        </button>
       </div>
 
       <ChromiumNotice tier={tier} />
@@ -527,17 +733,36 @@ function TweakView({
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
         {/* Preview + Code */}
         <div className="space-y-4">
-          {/* Background picker */}
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-500">BG:</span>
-            {GRADIENT_BGS.map((g, i) => (
-              <button key={g} onClick={() => { setBgIndex(-1); setGradientIndex(i); }} className={`w-6 h-6 rounded-full bg-gradient-to-br ${g} border-2 transition-colors ${bgIndex === -1 && gradientIndex === i ? "border-white" : "border-transparent"}`} />
-            ))}
-            {BG_IMAGES.slice(0, 4).map((_, i) => (
-              <button key={i} onClick={() => setBgIndex(i)} className={`w-6 h-6 rounded-full border-2 transition-colors flex items-center justify-center bg-slate-700 ${bgIndex === i ? "border-white" : "border-transparent"}`}>
-                <Image size={10} className="text-slate-400" />
-              </button>
-            ))}
+          {/* Background picker + Size presets */}
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-slate-500">BG:</span>
+              {GRADIENT_BGS.map((g, i) => (
+                <button key={g} onClick={() => { setBgIndex(-1); setGradientIndex(i); }} className={`w-6 h-6 rounded-full bg-gradient-to-br ${g} border-2 transition-colors ${bgIndex === -1 && gradientIndex === i ? "border-white" : "border-transparent"}`} />
+              ))}
+              {BG_IMAGES.slice(0, 4).map((_, i) => (
+                <button key={i} onClick={() => setBgIndex(i)} className={`w-6 h-6 rounded-full border-2 transition-colors flex items-center justify-center bg-slate-700 ${bgIndex === i ? "border-white" : "border-transparent"}`}>
+                  <Image size={10} className="text-slate-400" />
+                </button>
+              ))}
+            </div>
+            <div className="h-4 w-px bg-slate-700" />
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-slate-500">Size:</span>
+              {PREVIEW_SIZES.map((s) => (
+                <button
+                  key={s.key}
+                  onClick={() => setPreviewSize(s.key)}
+                  className={`px-2 py-0.5 rounded text-[11px] font-medium transition-colors ${
+                    previewSize === s.key
+                      ? "bg-slate-600 text-white"
+                      : "text-slate-500 hover:text-slate-300"
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
           </div>
 
           {/* Preview */}
@@ -551,6 +776,8 @@ function TweakView({
               gradientIndex={gradientIndex}
               previewRef={previewRef}
               onMouseMove={handleMouseMove}
+              panelWidth={panelWidth}
+              panelHeight={panelHeight}
             />
           ) : (
             <div
@@ -567,7 +794,12 @@ function TweakView({
                   style={{ top: "-7.5%", left: "-7.5%", transform: `translate(${mouseOffset.x}px, ${mouseOffset.y}px)` }}
                 />
               )}
-              <Glass template={tmplName} {...(options as Record<string, unknown>)} className="w-[280px] h-[200px] flex items-center justify-center transition-all duration-300">
+              <Glass
+                template={tmplName}
+                {...(options as Record<string, unknown>)}
+                className={`flex items-center justify-center transition-all duration-300 ${isFull ? "w-[90%] h-[80%]" : ""}`}
+                style={isFull ? undefined : { width: panelWidth, height: panelHeight }}
+              >
                 <div className="text-center px-4">
                   <p className="text-white/90 text-sm font-medium capitalize">{tmplName}</p>
                   <p className="text-white/50 text-xs mt-1">{template.name}</p>
@@ -608,7 +840,14 @@ function TweakView({
           {/* Parameters */}
           <div className="bg-slate-900/60 border border-slate-700/50 rounded-xl p-4">
             <div className="flex items-center justify-between mb-3">
-              <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Parameters</h4>
+              <div className="flex items-center gap-2">
+                <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Parameters</h4>
+                {modifiedCount > 0 && (
+                  <span className="text-[10px] text-blue-400 bg-blue-500/10 px-1.5 py-0.5 rounded-full">
+                    {modifiedCount} changed
+                  </span>
+                )}
+              </div>
               <button onClick={resetToTemplate} className="flex items-center gap-1 text-[11px] text-slate-500 hover:text-white transition-colors">
                 <RotateCcw size={10} /> Reset
               </button>
@@ -620,15 +859,42 @@ function TweakView({
                   <input type="color" value={tintColor} onChange={(e) => setTintColor(e.target.value)} className="w-7 h-7 rounded cursor-pointer bg-transparent border-0" />
                 </label>
               )}
-              {activeSliders.map((s) => (
-                <label key={s.key} className="block">
-                  <div className="flex justify-between text-xs mb-1">
-                    <span className="text-slate-400">{s.label}</span>
-                    <span className="text-slate-600 font-mono text-[11px] tabular-nums">{getValue(s.key, s.defaultValue)}</span>
+              {activeSliders.map((s) => {
+                const current = getValue(s.key, s.defaultValue);
+                const templateVal = getTemplateDefault(s.key);
+                const base = templateVal ?? s.defaultValue;
+                const isModified = current !== base;
+                return (
+                  <div key={s.key} className="group/slider">
+                    <div className="flex justify-between items-center text-xs mb-1">
+                      <div className="flex items-center gap-1.5">
+                        {isModified && <span className="w-1.5 h-1.5 rounded-full bg-blue-400 flex-shrink-0" />}
+                        <span className={isModified ? "text-slate-300" : "text-slate-400"}>{s.label}</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        {isModified && (
+                          <button
+                            onClick={() => setValues((p) => ({ ...p, [s.key]: base }))}
+                            className="opacity-0 group-hover/slider:opacity-100 transition-opacity text-slate-600 hover:text-slate-300"
+                            title="Reset to default"
+                          >
+                            <RotateCcw size={10} />
+                          </button>
+                        )}
+                        <EditableValue
+                          value={current}
+                          step={s.step}
+                          min={s.min}
+                          max={s.max}
+                          onChange={(v) => setValues((p) => ({ ...p, [s.key]: v }))}
+                          isModified={isModified}
+                        />
+                      </div>
+                    </div>
+                    <input type="range" min={s.min} max={s.max} step={s.step} value={current} onChange={(e) => setValues((p) => ({ ...p, [s.key]: Number(e.target.value) }))} className="w-full accent-blue-500 h-1" />
                   </div>
-                  <input type="range" min={s.min} max={s.max} step={s.step} value={getValue(s.key, s.defaultValue)} onChange={(e) => setValues((p) => ({ ...p, [s.key]: Number(e.target.value) }))} className="w-full accent-blue-500 h-1" />
-                </label>
-              ))}
+                );
+              })}
             </div>
           </div>
 
@@ -646,7 +912,17 @@ function TweakView({
 /*  Main Playground — state machine                  */
 /* ═══════════════════════════════════════════════ */
 export function Playground() {
-  const [activeTemplate, setActiveTemplate] = useState<number | null>(null);
+  const [activeTemplate, setActiveTemplate] = useState<number | null>(() => {
+    // Restore from URL hash on initial load
+    const decoded = decodeHashState(window.location.hash);
+    return decoded ? decoded.templateIndex : null;
+  });
+
+  // Clear hash when going back to browse
+  const handleBack = () => {
+    setActiveTemplate(null);
+    window.history.replaceState(null, "", window.location.pathname);
+  };
 
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
@@ -667,7 +943,7 @@ export function Playground() {
       ) : (
         <TweakView
           templateIndex={activeTemplate}
-          onBack={() => setActiveTemplate(null)}
+          onBack={handleBack}
           onSwitch={setActiveTemplate}
         />
       )}

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -86,6 +86,13 @@ function FrameworkTabs({ active, onChange }: { active: Framework; onChange: (f: 
 
 /* ─── Render Tier Badge ─── */
 function TierBadge({ tier }: { tier: string }) {
+  if (tier === "svg-backdrop") {
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded-full px-2 py-0.5">
+        <Gem size={10} /> SVG Backdrop
+      </span>
+    );
+  }
   if (tier === "svg-filter") {
     return (
       <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 rounded-full px-2 py-0.5">
@@ -187,7 +194,7 @@ const SURFACE_TYPES: { key: SurfaceType; label: string }[] = [
   { key: "lip", label: "Lip" },
 ];
 
-type FilterTab = "all" | "css" | "svg-filter" | "webgl";
+type FilterTab = "all" | "css" | "svg-filter" | "svg-backdrop" | "webgl";
 
 /* ═══════════════════════════════════════════════ */
 /*  Browse Mode — template gallery                  */
@@ -204,6 +211,7 @@ function BrowseView({ onSelect }: { onSelect: (index: number) => void }) {
     { key: "all", label: "All", count: TEMPLATES.length },
     { key: "css", label: "CSS", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "css").length },
     { key: "svg-filter", label: "SVG Filter", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "svg-filter").length },
+    { key: "svg-backdrop", label: "SVG Backdrop", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "svg-backdrop").length },
     { key: "webgl", label: "WebGL", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "webgl").length },
   ].filter((tab): tab is { key: FilterTab; label: string; count: number } => tab.key === "all" || tab.count > 0);
 
@@ -535,8 +543,8 @@ function TweakView({
                     <span className="font-medium">{t.name}</span>
                     <span className="text-[10px] text-slate-500 ml-2 capitalize">{t.template}</span>
                   </div>
-                  <span className={`text-[9px] ${templateRenderTiers[t.template] === "svg-filter" ? "text-emerald-400" : "text-violet-400"}`}>
-                    {templateRenderTiers[t.template] === "svg-filter" ? "SVG" : templateRenderTiers[t.template] === "webgl" ? "WebGL" : "CSS"}
+                  <span className={`text-[9px] ${templateRenderTiers[t.template] === "svg-backdrop" ? "text-amber-400" : templateRenderTiers[t.template] === "svg-filter" ? "text-emerald-400" : "text-violet-400"}`}>
+                    {templateRenderTiers[t.template] === "svg-backdrop" ? "SVG Backdrop" : templateRenderTiers[t.template] === "svg-filter" ? "SVG Filter" : templateRenderTiers[t.template] === "webgl" ? "WebGL" : "CSS"}
                   </span>
                 </button>
               ))}
@@ -545,11 +553,11 @@ function TweakView({
         </div>
       </div>
 
-      {/* Chromium notice */}
-      {isRefraction && (
+      {/* Chromium notice — only for svg-backdrop tier (backdrop-filter: url()) */}
+      {tier === "svg-backdrop" && (
         <div className="text-center mb-4">
           <span className="inline-flex items-center gap-2 text-xs text-yellow-400/80 bg-yellow-400/5 border border-yellow-400/20 rounded-full px-3 py-1">
-            Chromium only — backdrop-filter with SVG filters requires Chrome or Edge
+            Chromium 113+ only — <code className="font-mono">backdrop-filter: url()</code> requires Chrome or Edge
           </span>
         </div>
       )}
@@ -664,12 +672,12 @@ function TweakView({
 
           {/* Render tier footnote */}
           <p className="text-[11px] text-slate-600 leading-relaxed px-1">
-            {isRefraction ? (
-              <>Snell-Descartes displacement map via <code className="text-blue-400/60">feDisplacementMap</code>.</>
+            {tier === "svg-backdrop" ? (
+              <>SVG displacement via <code className="text-amber-400/60">backdrop-filter: url()</code> — Chromium 113+ only.</>
             ) : tier === "webgl" ? (
               <>WebGL — GPU-accelerated rendering with custom shaders.</>
             ) : tier === "svg-filter" ? (
-              <>SVG <code className="text-blue-400/60">feTurbulence</code> + <code className="text-blue-400/60">feDisplacementMap</code> via backdrop-filter.</>
+              <>SVG <code className="text-emerald-400/60">filter: url()</code> + <code className="text-emerald-400/60">backdrop-filter: blur()</code> — all modern browsers.</>
             ) : (
               <>Pure CSS — backdrop-filter, box-shadow, animations. All modern browsers.</>
             )}

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1,8 +1,9 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import { Glass, type TemplateName, templatePresets, type TemplatePresetName, templatePresetNames, templateRenderTiers } from "solid-glass";
 import { createLiquidGlass, type SurfaceType, SURFACE_EQUATIONS } from "solid-glass/engines/svg-refraction";
-import { RotateCcw, Image, Sparkles, Gem, Box, ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
+import { RotateCcw, Image, ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
 import { CodeBlock } from "../components/CodeBlock";
+import { RenderTierBadge, RenderTierTag, ChromiumNotice } from "../components/RenderTierTag";
 
 /* ─── Framework Code Generators ─── */
 type Framework = "react" | "vue" | "vanilla";
@@ -81,36 +82,6 @@ function FrameworkTabs({ active, onChange }: { active: Framework; onChange: (f: 
         </button>
       ))}
     </div>
-  );
-}
-
-/* ─── Render Tier Badge ─── */
-function TierBadge({ tier }: { tier: string }) {
-  if (tier === "svg-backdrop") {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded-full px-2 py-0.5">
-        <Gem size={10} /> SVG Backdrop
-      </span>
-    );
-  }
-  if (tier === "svg-filter") {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 rounded-full px-2 py-0.5">
-        <Gem size={10} /> SVG Filter
-      </span>
-    );
-  }
-  if (tier === "webgl") {
-    return (
-      <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded-full px-2 py-0.5">
-        <Box size={10} /> WebGL
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-medium bg-violet-500/10 text-violet-400 border border-violet-500/20 rounded-full px-2 py-0.5">
-      <Sparkles size={10} /> CSS
-    </span>
   );
 }
 
@@ -264,7 +235,7 @@ function BrowseView({ onSelect }: { onSelect: (index: number) => void }) {
               <div className="p-3">
                 <div className="flex items-center justify-between mb-1">
                   <span className="text-sm font-semibold text-slate-200 group-hover:text-white">{t.name}</span>
-                  <TierBadge tier={tier} />
+                  <RenderTierBadge tier={tier} />
                 </div>
                 <p className="text-xs text-slate-500">{t.description}</p>
                 <p className="text-[10px] text-slate-600 mt-1 capitalize">{t.template}</p>
@@ -523,7 +494,7 @@ function TweakView({
             className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-slate-800 border border-slate-700 text-sm text-slate-200 hover:border-slate-500 transition-colors"
           >
             {template.name}
-            <TierBadge tier={tier} />
+            <RenderTierBadge tier={tier} />
             <span className="text-[10px] text-slate-600 tabular-nums">{templateIndex + 1}/{TEMPLATES.length}</span>
             <ChevronDown size={14} className={`text-slate-500 transition-transform ${dropdownOpen ? "rotate-180" : ""}`} />
           </button>
@@ -543,9 +514,7 @@ function TweakView({
                     <span className="font-medium">{t.name}</span>
                     <span className="text-[10px] text-slate-500 ml-2 capitalize">{t.template}</span>
                   </div>
-                  <span className={`text-[9px] ${templateRenderTiers[t.template] === "svg-backdrop" ? "text-amber-400" : templateRenderTiers[t.template] === "svg-filter" ? "text-emerald-400" : "text-violet-400"}`}>
-                    {templateRenderTiers[t.template] === "svg-backdrop" ? "SVG Backdrop" : templateRenderTiers[t.template] === "svg-filter" ? "SVG Filter" : templateRenderTiers[t.template] === "webgl" ? "WebGL" : "CSS"}
-                  </span>
+                  <RenderTierBadge tier={templateRenderTiers[t.template]} />
                 </button>
               ))}
             </div>
@@ -553,14 +522,7 @@ function TweakView({
         </div>
       </div>
 
-      {/* Chromium notice — only for svg-backdrop tier (backdrop-filter: url()) */}
-      {tier === "svg-backdrop" && (
-        <div className="text-center mb-4">
-          <span className="inline-flex items-center gap-2 text-xs text-yellow-400/80 bg-yellow-400/5 border border-yellow-400/20 rounded-full px-3 py-1">
-            Chromium 113+ only — <code className="font-mono">backdrop-filter: url()</code> requires Chrome or Edge
-          </span>
-        </div>
-      )}
+      <ChromiumNotice tier={tier} />
 
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
         {/* Preview + Code */}
@@ -670,18 +632,10 @@ function TweakView({
             </div>
           </div>
 
-          {/* Render tier footnote */}
-          <p className="text-[11px] text-slate-600 leading-relaxed px-1">
-            {tier === "svg-backdrop" ? (
-              <>SVG displacement via <code className="text-amber-400/60">backdrop-filter: url()</code> — Chromium 113+ only.</>
-            ) : tier === "webgl" ? (
-              <>WebGL — GPU-accelerated rendering with custom shaders.</>
-            ) : tier === "svg-filter" ? (
-              <>SVG <code className="text-emerald-400/60">filter: url()</code> + <code className="text-emerald-400/60">backdrop-filter: blur()</code> — all modern browsers.</>
-            ) : (
-              <>Pure CSS — backdrop-filter, box-shadow, animations. All modern browsers.</>
-            )}
-          </p>
+          {/* Render tier — expandable explanation */}
+          <div className="px-1">
+            <RenderTierTag tier={tier} />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -181,8 +181,8 @@ function BrowseView({ onSelect }: { onSelect: (index: number) => void }) {
   const tabs: { key: FilterTab; label: string; count: number }[] = [
     { key: "all", label: "All", count: TEMPLATES.length },
     { key: "css", label: "CSS", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "css").length },
-    { key: "svg-filter", label: "SVG Filter", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "svg-filter").length },
-    { key: "svg-backdrop", label: "SVG Backdrop", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "svg-backdrop").length },
+    { key: "svg-filter", label: "SVG", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "svg-filter").length },
+    { key: "svg-backdrop", label: "Chrome only", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "svg-backdrop").length },
     { key: "webgl", label: "WebGL", count: TEMPLATES.filter((t) => templateRenderTiers[t.template] === "webgl").length },
   ].filter((tab): tab is { key: FilterTab; label: string; count: number } => tab.key === "all" || tab.count > 0);
 

--- a/packages/web/src/pages/Playground.tsx
+++ b/packages/web/src/pages/Playground.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import { Glass, type TemplateName, templatePresets, type TemplatePresetName, templatePresetNames, templateRenderTiers } from "solid-glass";
 import { createLiquidGlass, type SurfaceType, SURFACE_EQUATIONS } from "solid-glass/engines/svg-refraction";
-import { RotateCcw, Image, Sparkles, Gem, Box, ChevronLeft, ChevronDown } from "lucide-react";
+import { RotateCcw, Image, Sparkles, Gem, Box, ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
 import { CodeBlock } from "../components/CodeBlock";
 
 /* ─── Framework Code Generators ─── */
@@ -416,6 +416,22 @@ function TweakView({
     onSwitch(idx);
   };
 
+  // Keyboard navigation: left/right arrow keys
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        switchTemplate((templateIndex - 1 + TEMPLATES.length) % TEMPLATES.length);
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        switchTemplate((templateIndex + 1) % TEMPLATES.length);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [templateIndex]);
+
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     const rect = previewRef.current?.getBoundingClientRect();
     if (!rect) return;
@@ -467,7 +483,7 @@ function TweakView({
 
   return (
     <div>
-      {/* Header: back + template switcher */}
+      {/* Header: back + prev/next + template switcher */}
       <div className="flex items-center gap-3 mb-6">
         <button
           onClick={onBack}
@@ -476,6 +492,23 @@ function TweakView({
           <ChevronLeft size={16} /> Browse
         </button>
         <div className="h-4 w-px bg-slate-700" />
+        {/* Prev / Next buttons */}
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => switchTemplate((templateIndex - 1 + TEMPLATES.length) % TEMPLATES.length)}
+            className="p-1.5 rounded-lg bg-slate-800 border border-slate-700 text-slate-400 hover:text-white hover:border-slate-500 transition-colors"
+            aria-label="Previous template"
+          >
+            <ChevronLeft size={16} />
+          </button>
+          <button
+            onClick={() => switchTemplate((templateIndex + 1) % TEMPLATES.length)}
+            className="p-1.5 rounded-lg bg-slate-800 border border-slate-700 text-slate-400 hover:text-white hover:border-slate-500 transition-colors"
+            aria-label="Next template"
+          >
+            <ChevronRight size={16} />
+          </button>
+        </div>
         <div className="relative">
           <button
             onClick={() => setDropdownOpen(!dropdownOpen)}
@@ -483,6 +516,7 @@ function TweakView({
           >
             {template.name}
             <TierBadge tier={tier} />
+            <span className="text-[10px] text-slate-600 tabular-nums">{templateIndex + 1}/{TEMPLATES.length}</span>
             <ChevronDown size={14} className={`text-slate-500 transition-transform ${dropdownOpen ? "rotate-180" : ""}`} />
           </button>
           {dropdownOpen && (


### PR DESCRIPTION
## Summary

This PR refactors the render tier classification system to better reflect browser support reality, extracts render tier UI components into a reusable module, and significantly enhances the Playground with URL state persistence, keyboard navigation, editable parameters, and preview size controls.

## Key Changes

### Render Tier System Refactor
- **Renamed `svg-filter` → `svg-backdrop`** for the refraction engine to clarify that it uses `backdrop-filter: url()` (Chromium 113+ only), not standard SVG filters
- **Reclassified `crystal` and `smoke`** as `svg-filter` (not `svg-backdrop`) since they use standard `filter: url()` which is broadly supported
- **Removed fallback mappings** for `crystal` and `smoke` since they no longer need CSS fallbacks
- Updated render tier detection and fallback logic to match the new classification

### New RenderTierTag Component (`packages/web/src/components/RenderTierTag.tsx`)
- Extracted render tier UI into a centralized, reusable component module
- **`RenderTierBadge`** — compact badge for tight spaces (tables, dropdowns, card headers)
- **`RenderTierTag`** — expandable tag with browser compatibility info and technical details
- **`ChromiumNotice`** — inline banner for Chrome-only effects
- **`RenderTierInline`** — short compat label for inline use
- Single source of truth (`ENGINE_META`) for all render tier messaging across the site

### Playground Enhancements
- **URL hash state persistence** — template selection, parameter values, tint color, and surface type are encoded in the URL hash and restored on page load
- **Keyboard navigation** — arrow keys to switch between templates (left/right)
- **Editable parameter values** — click any parameter value to type a custom number
- **Preview size presets** — Card, Banner, Square, Full options with dynamic panel sizing
- **Share button** — copy shareable link with current state to clipboard
- **Grouped template dropdown** — templates organized by effect type for easier browsing
- **Modified parameter tracking** — visual indicators (blue dots, "changed" badge) show which parameters differ from template defaults
- **Per-slider reset** — reset individual parameters to template defaults without resetting all
- **Improved code generation** — only includes parameters that differ from defaults for cleaner output

### UI/UX Improvements
- Replaced generic `TierBadge` components across pages with the new `RenderTierBadge`
- Updated documentation tables to reflect new render tier names and browser support
- Enhanced parameter panel with modification indicators and inline editing
- Better visual feedback for template switching and parameter changes

## Implementation Details

- **Hash encoding format**: `#t=<index>&v=<key>:<val>,<key>:<val>&c=<color>&s=<surface>`
- **EditableValue component** handles inline number editing with validation and keyboard shortcuts
- **GroupedTemplateDropdown** uses `useMemo` to organize templates by effect type
- **Render tier metadata** centralized in `ENGINE_META` object for consistent messaging
- Parameter modification detection compares current values against template defaults, not slider defaults

https://claude.ai/code/session_01Bb1XH4rF8eMdVq9Qd5fWEN